### PR TITLE
Sets queueSize=500 for ignite, g-lifesci executors

### DIFF
--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -15,7 +15,14 @@ process {
     errorStrategy = { task.exitStatus == 14 ? 'retry' : 'terminate' }
     maxRetries = 100
 
-    executor = 'google-lifesciences'
+    executor {
+        $google-lifesciences {
+            queueSize = 500
+        }
+        $ignite {
+            queueSize = 500
+        }
+    }
     
     container = 'nfcore/rnaseq:1.3'
 

--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -12,7 +12,7 @@ process {
 	
     cache = 'lenient'
 
-    errorStrategy = { task.exitStatus == 14 ? 'retry' : 'terminate' }
+    errorStrategy = { task.attempt <= 100 ? 'retry' : 'ignore' }
     maxRetries = 100
 
     executor {


### PR DESCRIPTION
This PR adds in the file [executors/google_pipelines.config](https://github.com/pprieto/rmats-nf-private-fork/blob/master/conf/executors/google_pipelines.config#L32-L39) explicit specification of `executor.queueSize`. This is set to `500` for both executors utilised in the pipeline (`google-lifesciences`, `ignite`).

Also, set the `errorStrategy` for all processes to be retried based on `maxRetries` and regardless of exit status. We hope with this we will avoid termination of the pipeline, either due to temporary unavailability of the ncbi server or from pre-emptible machine shut down.