### PR TITLE
Simplifies queueSize specification

### DIFF
--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -15,7 +15,14 @@ process {
     errorStrategy = { task.exitStatus == 14 ? 'retry' : 'terminate' }
     maxRetries = 100
 
-    executor = 'google-lifesciences'
+    executor {
+        $google-lifesciences {
+            queueSize = 500
+        }
+        $ignite {
+            queueSize = 500
+        }
+    }
     
     container = 'nfcore/rnaseq:1.3'
 

--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -16,14 +16,10 @@ process {
     maxRetries = 100
 
     executor {
-        $google-lifesciences {
-            queueSize = 500
-        }
-        $ignite {
-            queueSize = 500
-        }
+        name = 'google-lifesciences' {
+        queueSize = 500
     }
-    
+
     container = 'nfcore/rnaseq:1.3'
 
     withName: 'getAccession' {

--- a/conf/executors/google_pipelines.config
+++ b/conf/executors/google_pipelines.config
@@ -12,7 +12,7 @@ process {
 	
     cache = 'lenient'
 
-    errorStrategy = { task.exitStatus == 14 ? 'retry' : 'terminate' }
+    errorStrategy = { task.attempt <= 100 ? 'retry' : 'ignore' }
     maxRetries = 100
 
     executor {


### PR DESCRIPTION
This PR simplifies the specification of `queueSize` and removes the specification of the executors, as the hyphen breaks the string for `google-lifesciences`.

Check here in `jaxT` workspace:
https://cloudos.lifebit.ai/public/jobs/5e6fd84ecf98a30104fec177

![image](https://user-images.githubusercontent.com/38183826/76795579-76574000-67c1-11ea-920c-15295923ef42.png)

In the docs the syntax looks like this when multiple executors are used, but the hyphen/dash in 
`google-lifesciences` seems to be breaking the string.